### PR TITLE
[#28] [HOTFIX] CaffeineTokenStore 변경으로 인한 import 경로 오류 해결

### DIFF
--- a/src/test/kotlin/com/plog/global/security/CaffeineTokenStoreTest.kt
+++ b/src/test/kotlin/com/plog/global/security/CaffeineTokenStoreTest.kt
@@ -2,7 +2,7 @@
 package com.plog.global.security
 
 import com.github.benmanes.caffeine.cache.Caffeine
-import com.plog.global.config.CacheConfig.CACHE_NAME
+import com.plog.global.config.CacheConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -35,7 +35,7 @@ class CaffeineTokenStoreTest {
     @BeforeEach
     fun setUp() {
         // 실제 Caffeine 설정과 유사하게 CacheManager를 수동 생성합니다.
-        cacheManager = CaffeineCacheManager(CACHE_NAME)
+        cacheManager = CaffeineCacheManager(CacheConfig.CACHE_NAME)
         cacheManager.setCaffeine(
             Caffeine.newBuilder()
                 .expireAfterWrite(7, TimeUnit.DAYS)


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #28 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

CaffeineTokenStoreTest에서 CACHE_NAME을 정상적으로 불러오지 못하는 오류를 해결합니다.

`import com.plog.global.config.CacheConfig`로 불러와서 `CacheConfig.CACHE_NAME`을 통해 사용하도록 변경했습니다.